### PR TITLE
Added c++11 flag to Makefile and removal of undefined behavior

### DIFF
--- a/fast_str/Makefile
+++ b/fast_str/Makefile
@@ -29,7 +29,7 @@ str_benchmark: strspn.o strcasecmp.o benchmark.o
 	gcc $(CFLAGS) -c $< -o $@
 
 benchmark.o : benchmark.cc
-	g++ -c $< -o $@
+	g++ -std=c++11 -c $< -o $@
 
 clean : FORCE
 	rm -f *.o* *~ str_benchmark

--- a/fast_str/strcasecmp.c
+++ b/fast_str/strcasecmp.c
@@ -456,13 +456,13 @@ stricmp_avx2(const unsigned char *s1, const unsigned char *s2, size_t len)
 
 	while (i + 8 <= len) {
 		c |= lct[s1[i]] ^ lct[s2[i]];
-		c |= lct[s1[++i]] ^ lct[s2[i]];
-		c |= lct[s1[++i]] ^ lct[s2[i]];
-		c |= lct[s1[++i]] ^ lct[s2[i]];
-		c |= lct[s1[++i]] ^ lct[s2[i]];
-		c |= lct[s1[++i]] ^ lct[s2[i]];
-		c |= lct[s1[++i]] ^ lct[s2[i]];
-		c |= lct[s1[++i]] ^ lct[s2[i]];
+		c |= (++i, lct[s1[i]] ^ lct[s2[i]]);
+		c |= (++i, lct[s1[i]] ^ lct[s2[i]]);
+		c |= (++i, lct[s1[i]] ^ lct[s2[i]]);
+		c |= (++i, lct[s1[i]] ^ lct[s2[i]]);
+		c |= (++i, lct[s1[i]] ^ lct[s2[i]]);
+		c |= (++i, lct[s1[i]] ^ lct[s2[i]]);
+		c |= (++i, lct[s1[i]] ^ lct[s2[i]]);
 		if (c)
 			return 1;
 		++i;
@@ -526,9 +526,9 @@ stricmp_avx2_64(const unsigned char *s1, const unsigned char *s2, size_t len)
 
 	while (i + 4 <= len) {
 		c |= lct[s1[i]] != lct[s2[i]];
-		c |= lct[s1[++i]] != lct[s2[i]];
-		c |= lct[s1[++i]] != lct[s2[i]];
-		c |= lct[s1[++i]] != lct[s2[i]];
+		c |= (++i, lct[s1[i]] != lct[s2[i]]);
+		c |= (++i, lct[s1[i]] != lct[s2[i]]);
+		c |= (++i, lct[s1[i]] != lct[s2[i]]);
 		if (c)
 			return 1;
 		++i;


### PR DESCRIPTION
Awesome blog post.

This just adds `std=c++11` to the Makefile (which I needed to do on OSX and Ubuntu) to compile the project and changes a couple lines to avoid unsequenced/modified access undefined behavior.

Apologies if I misunderstand something about those lines.  Code worked everywhere I tried it so perhaps this undefined behavior isn't really an issue.